### PR TITLE
fix: Update echogram generation endpoint URL

### DIFF
--- a/src/services/s3Service.ts
+++ b/src/services/s3Service.ts
@@ -46,7 +46,7 @@ export class S3Service {
   }
 
   static async generateEchogram(filename: string): Promise<Blob> {
-    const echogramApiUrl = `https://noaa-s3-backend.fly.dev/generate-echogram?filename=${filename}`;
+    const echogramApiUrl = `https://noaa-echogram.fly.dev/generate-echogram?filename=${filename}`;
     try {
       const response = await fetch(echogramApiUrl);
       if (!response.ok) {


### PR DESCRIPTION
Changed the backend URL for echogram generation to https://noaa-echogram.fly.dev/generate-echogram as requested.